### PR TITLE
Update exceptions dependency

### DIFF
--- a/Data/Pool.hs
+++ b/Data/Pool.hs
@@ -33,7 +33,7 @@ import           Control.Applicative
 import           Control.Concurrent
 import           Control.Concurrent.STM
 import           Control.Monad
-import           Control.Monad.Catch    (MonadCatch)
+import           Control.Monad.Catch    (MonadMask)
 import qualified Control.Monad.Catch    as E
 import           Control.Monad.IO.Class
 import           Data.Hashable          (hash)
@@ -108,7 +108,7 @@ createPool create destroy nStripes idleTime maxResources = do
 purgePool :: Pool a -> IO ()
 purgePool p = V.forM_ (localPools p) $ purgeLocalPool (destroy p)
 
-withResource :: (MonadIO m, MonadCatch m) => Pool a -> (a -> m b) -> m b
+withResource :: (MonadIO m, MonadMask m) => Pool a -> (a -> m b) -> m b
 {-# SPECIALIZE withResource :: Pool a -> (a -> IO b) -> IO b #-}
 withResource p act = E.mask $ \ restore -> do
     (r, lp) <- takeResource p
@@ -122,7 +122,7 @@ withResource p act = E.mask $ \ restore -> do
 -- returns immediately with 'Nothing' (ie. the action function is /not/ called).
 -- Conversely, if a resource can be borrowed from the pool without blocking, the
 -- action is performed and it's result is returned, wrapped in a 'Just'.
-tryWithResource :: (MonadIO m, MonadCatch m)
+tryWithResource :: (MonadIO m, MonadMask m)
                 => Pool a -> (a -> m b) -> m (Maybe b)
 {-# SPECIALIZE tryWithResource :: Pool a -> (a -> IO b) -> IO (Maybe b) #-}
 tryWithResource p act = E.mask $ \ restore -> do

--- a/ex-pool.cabal
+++ b/ex-pool.cabal
@@ -1,5 +1,5 @@
 name:                ex-pool
-version:             0.1.0.3
+version:             0.2
 synopsis:
   Another fork of resource-pool, with a MonadIO and MonadCatch constraint
 
@@ -29,7 +29,7 @@ library
   exposed-modules:   Data.Pool
   build-depends:
       base           == 4.*
-    , exceptions     <  0.6
+    , exceptions     == 0.6.*
     , hashable
     , stm
     , time


### PR DESCRIPTION
The first commits merely constrains `exceptions` to versions less than 0.6.
The second commit updates to `exceptions` 0.6.
